### PR TITLE
ci: update phplint action to version 9.4

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     # PHP Linter (https://github.com/marketplace/actions/check-php-syntax-errors)
     - name: Linter
-      uses: overtrue/phplint@8.0
+      uses: overtrue/phplint@9.4
       with:
         path: .
         options: --exclude=*.log


### PR DESCRIPTION
Update the phplint GitHub Action in the Laravel workflow from
version 8.0 to 9.4. This ensures we're using the latest version
of the linter, which may include bug fixes and improvements for
PHP syntax checking in our CI pipeline.