### PR TITLE
ci: disable auto-deploy and update PHP linter version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,9 @@ name: deploy
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   # pull_request:
   #   branches:
   #     - deploy_staging
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v2
     # PHP Linter (https://github.com/marketplace/actions/check-php-syntax-errors)
     - name: Linter
-      uses: overtrue/phplint@8.0
+      uses: overtrue/phplint@9.4
       with:
         path: .
         options: --exclude=*.log


### PR DESCRIPTION
Disable automatic deployment on push to main branch for more
controlled releases. Update PHP linter action to version 9.4 for
improved syntax checking and compatibility with newer PHP versions.