### PR TITLE
feat: add course instance to schema configuration

### DIFF
--- a/app/Http/Livewire/Details.php
+++ b/app/Http/Livewire/Details.php
@@ -75,7 +75,10 @@ $sdPublishdate = $program->program_last_updated;
             ->sdPublisher('Texas Workforce Commission')
             ->sdDatePublished($sdPublishdate)
             ->url($program->program_url);
-
+            $schema->hasCourseInstance(
+                Schema::courseInstance()
+                    ->courseMode($program->program_format)
+                    ->location($program->provider_campus_name)); 
         $schema->offers(
             Schema::offer()->price($program->cost)
                 ->priceCurrency('USD')


### PR DESCRIPTION
Introduce courseInstance to the schema setup in Details.php
to include courseMode and location. This enhances the
structured data for better representation of program format
and campus name, improving data richness for search engines.