### PR TITLE
chore: comment out debug info message in seeder

### DIFF
--- a/database/seeders/ProgramSeeder.php
+++ b/database/seeders/ProgramSeeder.php
@@ -68,7 +68,7 @@ class ProgramSeeder extends Seeder
                 $programData
             );
 
-            $this->command->info("Processed record {$counter}");
+            // $this->command->info("Processed record {$counter}");
             $counter++;
         }
 


### PR DESCRIPTION
Comment out the debug information message that outputs each
processed record during seeding. This change is made to reduce
console clutter and improve the readability of seeding output.