### PR TITLE
refactor: rename workLoad to courseWorkload

### DIFF
--- a/app/Http/Livewire/Details.php
+++ b/app/Http/Livewire/Details.php
@@ -79,7 +79,7 @@ $sdPublishdate = $program->program_last_updated;
                 Schema::courseInstance()
                     ->courseMode("Blended")
                     ->location($program->provider_campus_name)
-                    ->workLoad($program_length_8601_format)
+                    ->courseWorkload($program_length_8601_format)
         );
         $schema->offers(
             Schema::offer()->price($program->cost)


### PR DESCRIPTION
Rename workLoad method to courseWorkload in Details.php for
consistency and clarity in codebase. Aligns with established
naming conventions across the application.